### PR TITLE
Add support for other keyboard layouts

### DIFF
--- a/hopsearch-extension/content.js
+++ b/hopsearch-extension/content.js
@@ -61,8 +61,8 @@ function getDomain(href) {
 
 function keyUpHandler(e) {
     // console.log(`Released in content: ${e.code}`);
-    if (e.code === 'Comma') pressedA = false;
-    if (e.code === 'Period' && pressedA) {
+    if (e.key === ',') pressedA = false;
+    if (e.key === '.' && pressedA) {
         console.log('Key-combo matched! Trying to move to search field.');
         chrome.storage.sync.get(getDomain(window.location.href), function (result) {
             if (result == null || Object.keys(result).length === 0) {
@@ -85,7 +85,7 @@ function keyUpHandler(e) {
 
 function keyDownHandler(e) {
     // console.log(`Pressed in content: ${e.code}`);
-    if (e.code === 'Comma') pressedA = true;
+    if (e.key === ',') pressedA = true;
 }
 
 function clickHandlerForLocatingSearchBox(e) {


### PR DESCRIPTION
Hello! 👋
When I set the extension up on my browser, I tried to use it but it didn't seem to catch the keys I was pressing - nothing happened when I used `Comma+Period`.
I took a look at the code and did some testing. I use a Turkish Q Layout (shown [here](https://docs.microsoft.com/en-us/globalization/keyboards/kbdtuq.html)) and it appeared to me that the `code` properties of the KeyboardEvents returned `Backslash` and `Slash` when I pressed the comma and period keys.

This PR uses [the `key` property](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) instead of `code` which I think might be a better way to test which key is being pressed in terms of universality

From [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code):
> The `KeyboardEvent.code` property represents a physical key on the keyboard (as opposed to the character generated by pressing the key).
